### PR TITLE
Add Yuzu API to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ If you are interested in GraphQL in general, check out [awesome-graphql](https:/
 | Yelp  | User Reviews and Recommendations of Top Restaurants, Shopping, Nightlife, Entertainment, Services and More | [Try it!](https://www.yelp.com/developers/graphiql) | [Docs](https://www.yelp.com/developers/graphql/guides/intro)
 | TravelgateX | The global marketplace for the travel trade | [Try it!](https://api.travelgatex.com/) | [Docs](https://docs.travelgatex.com/getting-started/)
 | TCGdex | A Multilanguage Pokémon TCG Database with Cards Pictures and most of the informations contained on the cards. | [Try it!](https://api.tcgdex.net/v2/graphql) | [Repo](https://github.com/tcgdex/cards-database)
+| Yuzu | Real-time financial data API: Stocks, Crypto, Forex and more. | [Try it!](https://graph.yuzu.dev/graphql) | [Docs](https://www.yuzu.dev/docs/graphql-api)
 
 ## Unofficial API proxies
 


### PR DESCRIPTION
Adds [Yuzu.dev](https://www.yuzu.dev)'s GraphQL API to the readme.